### PR TITLE
Add note about building the image on non-linux systems using docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ $ apt-get update -o Acquire::Check-Valid-Until=false
 
 ### Docker
 
+**NOTE:** Currently the image can only be build with docker on Linux system 
+
 Using our [Dockerfile](docker/Dockerfile) you create your own Docker container
 that is used to build a VyOS ISO image or other required VyOS packages. The
 [Dockerfile](docker/Dockerfile) contains some of the most used packages needed


### PR DESCRIPTION
Currently it is only working on linux systems (using docker).

References:

https://vyos.slack.com/archives/C976FK9S6/p1563449957056500
https://forum.vyos.io/t/make-iso-failed/3288
